### PR TITLE
Implement safe parsing when `body` is not base64-encoded

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -113,23 +113,9 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 	var transferEncoding string = "json"
 
 	if logBody && len(request.Body) != 0 {
-		if request.IsBase64Encoded {
-			switch isBase64String(request.Body) {
-			case true:
-				transformReqBody = request.Body
-				transferEncoding = "base64"
-			case false:
-				// Meaning body isn't a valid base64-encoded string despite
-				// `IsBase64Encoded``  being `true`.
-				// So we try to pass it on to `processBody`. If the body is not a
-				// valid JSON, we encode it to base64.
-				transformReqBody, transferEncoding = processBody(request.Body)
-				// We want to set `transferEncoding` to empty string if `transferEncoding`
-				// is JSON. This parallels our implementation in Node.js Lambda middleware.
-				if transferEncoding == "json" {
-					transferEncoding = ""
-				}
-			}
+		if request.IsBase64Encoded && isBase64String(request.Body) {
+			transformReqBody = request.Body
+			transferEncoding = "base64"
 		} else {
 			transformReqBody, transferEncoding = processBody(request.Body)
 		}
@@ -157,7 +143,7 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 	transferEncoding = "json"
 
 	if logBody && len(response.Body) != 0 {
-		if response.IsBase64Encoded {
+		if response.IsBase64Encoded && isBase64String(response.Body) {
 			transformRespBody = response.Body
 			transferEncoding = "base64"
 		} else {

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package moesifawslambda
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -114,9 +113,23 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 	var transferEncoding string = "json"
 
 	if logBody && len(request.Body) != 0 {
-		if request.IsBase64Encoded && isBase64String(request.Body) {
-			transformReqBody = request.Body
-			transferEncoding = "base64"
+		if request.IsBase64Encoded {
+			switch isBase64String(request.Body) {
+			case true:
+				transformReqBody = request.Body
+				transferEncoding = "base64"
+			case false:
+				// Meaning body isn't a valid base64-encoded string despite
+				// `IsBase64Encoded``  being `true`.
+				// So we try to pass it on to `processBody`. If the body is not a
+				// valid JSON, we encode it to base64.
+				transformReqBody, transferEncoding = processBody(request.Body)
+				// We want to set `transferEncoding` to empty string if `transferEncoding`
+				// is JSON. This parallels our implementation in Node.js Lambda middleware.
+				if transferEncoding == "json" {
+					transferEncoding = ""
+				}
+			}
 		} else {
 			transformReqBody, transferEncoding = processBody(request.Body)
 		}
@@ -149,9 +162,6 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 			transferEncoding = "base64"
 		} else {
 			transformRespBody, transferEncoding = processBody(response.Body)
-			fmt.Println("HERE IS THE RESP BODY AND TX========>")
-			fmt.Printf("%s\n===========>", transformRespBody)
-			fmt.Printf("%s\n=========>", transferEncoding)
 		}
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -1,15 +1,20 @@
 package moesifawslambda
 
 import (
-	"net/url"
-	"log"
-	"time"
+	b64 "encoding/base64"
 	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	models "github.com/moesif/moesifapi-go/models"
-	b64 "encoding/base64"
-	"net/http"
 )
+
+const Base64 string = "^[A-Za-z0-9+/]+={0,2}$"
 
 func prepareRequestURI(request events.APIGatewayProxyRequest) string {
 	var uri string
@@ -57,28 +62,34 @@ func prepareRequestURI(request events.APIGatewayProxyRequest) string {
 	return uri
 }
 
+func isBase64String(str string) bool {
+	b64Regex, err := regexp.Compile(Base64)
+	if err != nil {
+		return false
+	}
+	return b64Regex.MatchString(str)
+}
+
 func processBody(body string) (interface{}, string) {
 	var parsedBody interface{}
 	var transferEncoding string
 
 	parsedBody = nil
 	transferEncoding = "json"
-	if logBody {
-		if jsonMarshalErr := json.Unmarshal([]byte(body), &parsedBody); jsonMarshalErr != nil {
-			if debug {
-				log.Printf("About to parse request body as base64 ")
-			}
-			parsedBody = b64.StdEncoding.EncodeToString([]byte(body))
-			transferEncoding = "base64"
-			if debug {
-				log.Printf("Parsed request body as base64 - %s", parsedBody)
-			}
+	if jsonMarshalErr := json.Unmarshal([]byte(body), &parsedBody); jsonMarshalErr != nil {
+		if debug {
+			log.Printf("About to parse request body as base64 ")
+		}
+		parsedBody = b64.StdEncoding.EncodeToString([]byte(body))
+		transferEncoding = "base64"
+		if debug {
+			log.Printf("Parsed request body as base64 - %s", parsedBody)
 		}
 	}
 	return parsedBody, transferEncoding
 }
 
-func processHeaders(headers map[string] string) map[string] string {
+func processHeaders(headers map[string]string) map[string]string {
 	// Check if the headers are empty
 	if len(headers) == 0 {
 		var emptyHeaders = map[string]string{}
@@ -99,33 +110,57 @@ func defaultSourceIp(request events.APIGatewayProxyRequest) *string {
 func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGatewayProxyResponse, apiVersion *string, userId *string, companyId string, sessionToken string, metadata map[string]interface{}) models.EventModel {
 
 	reqTime := time.Now().UTC()
-	transformReqBody, transferEncoding := processBody(request.Body)
+	var transformReqBody interface{} = nil
+	var transferEncoding string = "json"
+
+	if logBody && len(request.Body) != 0 {
+		if request.IsBase64Encoded && isBase64String(request.Body) {
+			transformReqBody = request.Body
+			transferEncoding = "base64"
+		} else {
+			transformReqBody, transferEncoding = processBody(request.Body)
+		}
+	}
 
 	var transformReqHeaders = make(map[string][]string)
-	for  key, value := range request.Headers {
+	for key, value := range request.Headers {
 		transformReqHeaders[key] = []string{value}
 	}
 
 	eventRequestModel := models.EventRequestModel{
-		Time:       &reqTime,
-		Uri:        prepareRequestURI(request),
-		Verb:       request.HTTPMethod,
-		ApiVersion: apiVersion,
-		IpAddress: getClientIp(transformReqHeaders, defaultSourceIp(request)),
-		Headers: processHeaders(request.Headers),
-		Body: &transformReqBody,
+		Time:             &reqTime,
+		Uri:              prepareRequestURI(request),
+		Verb:             request.HTTPMethod,
+		ApiVersion:       apiVersion,
+		IpAddress:        getClientIp(transformReqHeaders, defaultSourceIp(request)),
+		Headers:          processHeaders(request.Headers),
+		Body:             &transformReqBody,
 		TransferEncoding: &transferEncoding,
 	}
 
 	rspTime := time.Now().UTC()
-	transformRespBody, transferEncoding := processBody(response.Body)
+
+	var transformRespBody interface{}
+	transferEncoding = "json"
+
+	if logBody && len(response.Body) != 0 {
+		if response.IsBase64Encoded {
+			transformRespBody = response.Body
+			transferEncoding = "base64"
+		} else {
+			transformRespBody, transferEncoding = processBody(response.Body)
+			fmt.Println("HERE IS THE RESP BODY AND TX========>")
+			fmt.Printf("%s\n===========>", transformRespBody)
+			fmt.Printf("%s\n=========>", transferEncoding)
+		}
+	}
 
 	eventResponseModel := models.EventResponseModel{
-		Time:      &rspTime,
-		Status:    response.StatusCode,
-		IpAddress: nil,
-		Headers: processHeaders(response.Headers),
-		Body: &transformRespBody,
+		Time:             &rspTime,
+		Status:           response.StatusCode,
+		IpAddress:        nil,
+		Headers:          processHeaders(response.Headers),
+		Body:             &transformRespBody,
 		TransferEncoding: &transferEncoding,
 	}
 
@@ -139,7 +174,7 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 		Tags:         nil,
 		UserId:       userId,
 		CompanyId:    &companyId,
-		Metadata: 	  &metadata,
+		Metadata:     &metadata,
 		Direction:    &direction,
 		Weight:       &weight,
 	}
@@ -148,7 +183,7 @@ func prepareEvent(request events.APIGatewayProxyRequest, response events.APIGate
 
 // Send Outgoing Event to Moesif
 func sendMoesifOutgoingAsync(request *http.Request, reqTime time.Time, apiVersion *string, reqBody interface{}, reqEncoding *string,
-	rspTime time.Time, respStatus int, respHeader http.Header, respBody interface{}, respEncoding *string, userId *string, 
+	rspTime time.Time, respStatus int, respHeader http.Header, respBody interface{}, respEncoding *string, userId *string,
 	companyId *string, sessionToken *string, metadata map[string]interface{}, direction *string, weight *int) {
 
 	// Get Client Ip
@@ -156,47 +191,47 @@ func sendMoesifOutgoingAsync(request *http.Request, reqTime time.Time, apiVersio
 
 	// Prepare request model
 	event_request := models.EventRequestModel{
-	Time:       &reqTime,
-	Uri:        request.URL.Scheme + "://" + request.Host + request.URL.Path,
-	Verb:       request.Method,
-	ApiVersion: apiVersion,
-	IpAddress:  ip,
-	Headers:    request.Header,
-	Body: 		&reqBody,
-	TransferEncoding: reqEncoding,
+		Time:             &reqTime,
+		Uri:              request.URL.Scheme + "://" + request.Host + request.URL.Path,
+		Verb:             request.Method,
+		ApiVersion:       apiVersion,
+		IpAddress:        ip,
+		Headers:          request.Header,
+		Body:             &reqBody,
+		TransferEncoding: reqEncoding,
 	}
 
 	// Prepare response model
 	event_response := models.EventResponseModel{
-	Time:      &rspTime,
-	Status:    respStatus,
-	IpAddress: nil,
-	Headers:   respHeader,
-	Body: 	   respBody,
-	TransferEncoding: respEncoding,
+		Time:             &rspTime,
+		Status:           respStatus,
+		IpAddress:        nil,
+		Headers:          respHeader,
+		Body:             respBody,
+		TransferEncoding: respEncoding,
 	}
 
 	// Prepare the event model
 	event := models.EventModel{
-	Request:      event_request,
-	Response:     event_response,
-	SessionToken: sessionToken,
-	Tags:         nil,
-	UserId:       userId,
-	CompanyId:    companyId,
-	Metadata: 	  metadata,
-	Direction:    direction,
-	Weight:       weight,
+		Request:      event_request,
+		Response:     event_response,
+		SessionToken: sessionToken,
+		Tags:         nil,
+		UserId:       userId,
+		CompanyId:    companyId,
+		Metadata:     metadata,
+		Direction:    direction,
+		Weight:       weight,
 	}
 
 	// Send event to moesif
 	_, err := apiClient.CreateEvent(&event)
-	
+
 	// Log the message
 	if err != nil {
 		log.Fatalf("Error while sending event to Moesif: %s.\n", err.Error())
 	}
-	
+
 	if debug {
 		log.Printf("Successfully sent outgoing event to Moesif")
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,115 @@
+package moesifawslambda
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func MoesifOptions() map[string]interface{} {
+	var moesifOptions = map[string]interface{}{
+		"Application_Id":    "",
+		"Api_Version":       "1.0.0",
+		"Debug":             true,
+		"Log_Body":          true,
+		"Log_Body_Outgoing": true,
+	}
+	return moesifOptions
+}
+
+func HandleLambdaEvent(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return events.APIGatewayProxyResponse{
+		Body:       request.Body,
+		StatusCode: 200,
+		Headers: map[string]string{
+			"RspHeader1":     "RspHeaderValue1",
+			"Content-Type":   "application/json",
+			"Content-Length": "1000",
+		},
+	}, nil
+}
+
+// Generates mock `events.APIGatewayProxyRequest` request objects.
+func generateProxyReq(body []byte, isb64Encoded bool) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		Resource:                        "foo/bar",
+		Path:                            "foo/bar/dev",
+		HTTPMethod:                      "POST",
+		Headers:                         map[string]string{"Content-Type": "application/json"},
+		MultiValueHeaders:               map[string][]string{"X-Forwarded-Proto": {"https"}},
+		QueryStringParameters:           map[string]string{"foo": "bar"},
+		MultiValueQueryStringParameters: map[string][]string{"foo": {"bar"}},
+		PathParameters:                  map[string]string{"proxy": "/path/to/resource"},
+		StageVariables:                  map[string]string{"baz": "bar"},
+		RequestContext:                  events.APIGatewayProxyRequestContext{},
+		Body:                            string(body),
+		IsBase64Encoded:                 isb64Encoded,
+	}
+}
+
+// This function mocks a portion of `prepareEvent` that processes the request body
+// and calls `processBody` accordingly.
+// Returns the same as `processBody`.
+func mockPrepareEvent(request events.APIGatewayProxyRequest) (interface{}, string) {
+	var transformReqBody interface{} = nil
+	var transferEncoding string = "json"
+
+	if logBody && len(request.Body) != 0 {
+		if request.IsBase64Encoded && isBase64String(request.Body) {
+			transformReqBody = request.Body
+			transferEncoding = "base64"
+		} else {
+			fmt.Println("I am here!!==========>")
+			transformReqBody, transferEncoding = processBody(request.Body)
+		}
+	}
+	return transformReqBody, transferEncoding
+}
+
+func TestProcessBody(t *testing.T) {
+
+	var proxyReqWithJsonStrBody = generateProxyReq([]byte(`{"foo": "bar"}`), false)
+	var proxyReqWithBase64StrBody = generateProxyReq([]byte(`eyJmb28iOiAiYmFyIn0=`), true)
+	var proxyReqWithInvalidBase64StrBody = generateProxyReq([]byte(`{"foo": "bar"}`), true)
+
+	type expected struct {
+		expectedBody             interface{}
+		expectedTransferEncoding string
+	}
+
+	var testcases = []struct {
+		in  events.APIGatewayProxyRequest
+		out expected
+	}{
+		{proxyReqWithJsonStrBody, expected{expectedBody: map[string]interface{}{"foo": "bar"}, expectedTransferEncoding: "json"}},
+		{proxyReqWithBase64StrBody, expected{expectedBody: "eyJmb28iOiAiYmFyIn0=", expectedTransferEncoding: "base64"}},
+		{proxyReqWithInvalidBase64StrBody, expected{expectedBody: "eyJmb28iOiAiYmFyIn0=", expectedTransferEncoding: "base64"}},
+	}
+
+	for _, tt := range testcases {
+
+		res := MoesifLogger(HandleLambdaEvent, MoesifOptions())
+
+		result, err := res(context.Background(), tt.in)
+		if err != nil {
+			t.Logf("encountered error\n")
+			t.Logf("===========\n")
+			t.Log(result)
+			t.Logf("\n===========\n")
+		}
+
+		parsedBody, transferEncoding := mockPrepareEvent(tt.in)
+
+		if transferEncoding != tt.out.expectedTransferEncoding {
+			t.Errorf("got %v, want %v", transferEncoding, tt.out.expectedTransferEncoding)
+		}
+		if !reflect.DeepEqual(parsedBody, tt.out.expectedBody) {
+			t.Errorf("got %v, want %v", parsedBody, tt.out.expectedBody)
+		}
+
+	}
+
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -57,23 +57,9 @@ func mockPrepareEvent(request events.APIGatewayProxyRequest) (interface{}, strin
 	var transferEncoding string = "json"
 
 	if logBody && len(request.Body) != 0 {
-		if request.IsBase64Encoded {
-			switch isBase64String(request.Body) {
-			case true:
-				transformReqBody = request.Body
-				transferEncoding = "base64"
-			case false:
-				// Meaning body isn't a valid base64-encoded string despite
-				// `IsBase64Encoded``  being `true`.
-				// So we try to pass it on to `processBody`. If the body is not a
-				// valid JSON, we encode it to base64.
-				transformReqBody, transferEncoding = processBody(request.Body)
-				// We want to set `transferEncoding` to empty string if `transferEncoding`
-				// is JSON. This parallels our implementation in Node.js Lambda middleware.
-				if transferEncoding == "json" {
-					transferEncoding = ""
-				}
-			}
+		if request.IsBase64Encoded && isBase64String(request.Body) {
+			transformReqBody = request.Body
+			transferEncoding = "base64"
 		} else {
 			transformReqBody, transferEncoding = processBody(request.Body)
 		}
@@ -98,7 +84,7 @@ func TestProcessBody(t *testing.T) {
 	}{
 		{proxyReqWithJsonStrBody, expected{expectedBody: map[string]interface{}{"foo": "bar"}, expectedTransferEncoding: "json"}},
 		{proxyReqWithBase64StrBody, expected{expectedBody: "eyJmb28iOiAiYmFyIn0=", expectedTransferEncoding: "base64"}},
-		{proxyReqWithInvalidBase64StrBody, expected{expectedBody: map[string]interface{}{"foo": "bar"}, expectedTransferEncoding: ""}},
+		{proxyReqWithInvalidBase64StrBody, expected{expectedBody: map[string]interface{}{"foo": "bar"}, expectedTransferEncoding: "json"}},
 	}
 
 	for _, tt := range testcases {


### PR DESCRIPTION
## Local test result logs

```
=== RUN   TestProcessBody
2024/10/09 20:12:45 Sending the event to Moesif
2024/10/09 20:12:52 Successfully sent event to Moesif
2024/10/09 20:12:52 About to parse request body as base64 
2024/10/09 20:12:52 Parsed request body as base64 - ZXlKbWIyOGlPaUFpWW1GeUluMD0=
2024/10/09 20:12:52 Sending the event to Moesif
2024/10/09 20:12:53 Successfully sent event to Moesif
2024/10/09 20:12:53 Sending the event to Moesif
2024/10/09 20:12:54 Successfully sent event to Moesif
--- PASS: TestProcessBody (8.67s)
PASS
ok      github.com/moesif/moesif-aws-lambda-go  8.675s
```

## Web Portal screenshots for local tests
<details>
<summary>Request and response for first test case</summary>

![image](https://github.com/user-attachments/assets/05cb0daf-f311-44df-b6ab-2c7ad9035d85)

![image](https://github.com/user-attachments/assets/b393950f-8aad-4667-bcfa-e91f1513a791)

</details>

<details>
<summary>Request and response for second test case</summary>

![image](https://github.com/user-attachments/assets/8c866c94-d467-4f67-9246-56d8bb38f5c4)

![image](https://github.com/user-attachments/assets/b60f5477-4a14-43ac-8121-bdf556faef17)

</details>

<details>
<summary>Request and response for third test case</summary>

![image](https://github.com/user-attachments/assets/e00bcd61-7970-41cb-a4cf-28c5764f2d18)

![image](https://github.com/user-attachments/assets/3723781e-f871-414d-8cc4-fee3c36a8c1d)

</details>

## Request Event Model structures for local tests
All converted to JSON for better readability.

### First test case
```json
{
  "time": "2024-10-09T14:46:06.447952744Z",
  "uri": "http://localhost/?foo=bar",
  "verb": "POST",
  "headers": {
    "Content-Type": "application/json"
  },
  "api_version": "1.0.0",
  "body": {
    "foo": "bar"
  },
  "transfer_encoding": "json"
}
```

### Second test case
```json
{
  "time": "2024-10-09T14:46:07.305777576Z",
  "uri": "http://localhost/?foo=bar",
  "verb": "POST",
  "headers": {
    "Content-Type": "application/json"
  },
  "api_version": "1.0.0",
  "body": "eyJmb28iOiAiYmFyIn0=",
  "transfer_encoding": "base64"
}
```

### Third test case
```json
{
  "time": "2024-10-09T14:46:07.70559724Z",
  "uri": "http://localhost/?foo=bar",
  "verb": "POST",
  "headers": {
    "Content-Type": "application/json"
  },
  "api_version": "1.0.0",
  "body": {
    "foo": "bar"
  },
  "transfer_encoding": "json"
}
```

## Cloud test results with AWS Gateway REST API proxy
The Lambda function used for the test case:

```go
func HandleLambdaEvent(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
	return events.APIGatewayProxyResponse{
		Body:       request.Body,
		StatusCode: 200,
		Headers: map[string]string{
			"RspHeader1":     "RspHeaderValue1",
			"Content-Type":   "application/json",
			"Content-Length": "1000",
		},
	}, nil
}
```
[Configuration options used](https://github.com/Moesif/moesif-aws-lambda-go-example/blob/master/moesif_options/moesif_options.go).

### Web Portal screenshots
<details>
<summary>See screenshots</summary>

![image](https://github.com/user-attachments/assets/13a1d3db-d8df-40ee-b402-e3a847c888df)

![image](https://github.com/user-attachments/assets/ee1b58e8-f24e-494e-b7a7-228c6ad08134)

![image](https://github.com/user-attachments/assets/bb1637c5-4255-4a5e-a5a3-3f9da1892bbb)

</details>

### Request Event Model structure

```json
{
  "time": "2024-10-09T14:55:38.499150987Z",
  "uri": "https://****.execute-api.ap-southeast-2.amazonaws.com/",
  "verb": "POST",
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate, br",
    "Cache-Control": "no-cache",
    "Content-Type": "application/json",
    "Host": "****.execute-api.ap-southeast-2.amazonaws.com",
    "Postman-Token": "0ffce5a9-2a15-4fbd-a184-531e06d6f46a",
    "User-Agent": "PostmanRuntime/7.38.0",
    "X-Amzn-Trace-Id": "Root=1-6706996a-6ae69ef220938ec323876c28",
    "X-Forwarded-For": "103.251.247.89",
    "X-Forwarded-Port": "443",
    "X-Forwarded-Proto": "https"
  },
  "api_version": "1.0.0",
  "ip_address": "103.251.247.89",
  "body": {
    "email": "alex@example.com",
    "name": "Alex",
    "year": 2024
  },
  "transfer_encoding": "json"
}
```